### PR TITLE
Includes should be comma separated

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=The goal of this library is to provide performance when controlling a 
 category=Device Control
 url=https://github.com/Lynxmotion/AlternativeLSS
 architectures=*
-includes=LynxmotionLSS.h LssCommunication.h LssHandlers.h
+includes=LynxmotionLSS.h,LssCommunication.h,LssHandlers.h


### PR DESCRIPTION
From the specs:

> includes - (available from Arduino IDE 1.6.10) (optional) a **comma separated** list of files to be added to the sketch as #include <...> lines. This property is used with the "Include library" command in the Arduino IDE. If the includes property is missing, all the header files (.h) on the root source folder are included.